### PR TITLE
Only print debounce_ms when debugging

### DIFF
--- a/lua/vimway-lsp-diag/init.lua
+++ b/lua/vimway-lsp-diag/init.lua
@@ -36,7 +36,10 @@ function M.init(opts)
   end
 
   q.debounce_ms = M.debounce_ms
-  print(q.debounce_ms)
+
+  if M.debug then
+    print(q.debounce_ms)
+  end
 
   if opts['buf_clients_only'] ~= nil then
     M.buf_clients_only = opts['buf_clients_only']


### PR DESCRIPTION
I noticed that when I start vim it printed `50`. After bisecting through my plugins, I found that the print in `init` was the source of the print.

This PR guards that print with `M.debug`, so that you only see it when that option is enabled.