### PR TITLE
Update qflist call

### DIFF
--- a/lua/diaglist/quickfix.lua
+++ b/lua/diaglist/quickfix.lua
@@ -111,7 +111,7 @@ local function populate_qflist(open_qflist)
 
   local all_diagnostics = get_all_diagnostics_as_qfitems(priority_filename)
   if lsp.buf.server_ready() then
-    lsp.util.set_qflist(all_diagnostics)
+    setqflist(all_diagnostics)
     if open_qflist then
       if M.debug then
         print('setting foreign to false')


### PR DESCRIPTION
Change neovim API call vim.lsp.util.set_qflist() to setqflist() per
https://neovim.io/doc/user/deprecated.html under LSP utility functions.
