### PR TITLE
Export `populate_qflist()` publicly

### DIFF
--- a/lua/diaglist/quickfix.lua
+++ b/lua/diaglist/quickfix.lua
@@ -13,7 +13,7 @@ local function is_qf_foreign()
   return vim.fn.getqflist{ title = 0 }.title ~= M.title
 end
 
-local function populate_qflist()
+M.populate_qflist = function()
   local priority_uri = vim.uri_from_bufnr(0)
 
   -- entering same buffer as we were before focusing quickfix
@@ -38,7 +38,7 @@ local function populate_qflist()
 end
 
 M.open_all_diagnostics = function()
-  populate_qflist()
+  M.populate_qflist()
   api.nvim_command('copen')
 end
 
@@ -53,7 +53,7 @@ M.diagnostics_hook = function()
 end
 
 function M.init()
-  M.debounced_populate_qflist = debounce_trailing(M.debounce_ms, populate_qflist)
+  M.debounced_populate_qflist = debounce_trailing(M.debounce_ms, M.populate_qflist)
 end
 
 return M


### PR DESCRIPTION
This PR exports the local function `populate_qflist()` in `lua/diaglist/quickfix.lua`.

This allows, for example, to start the live-updating on `LspAttach` event without displaying the quickfix window:
```lua
require 'diaglist'.init() -- Initialize
vim.api.nvim_create_autocmd('LspAttach', {
	callback = function()
		require 'diaglist.quickfix'.populate_qflist() -- Starts live-updating
	end
})
```
```lua
use {
	'onsails/diaglist.nvim',
	event = { 'LspAttach' },
	config = function()
		require 'diaglist'.init()
		require 'diaglist.quickfix'.populate_qflist()
	end
}
```