### PR TITLE
Refactor: Replace with Neovim Lua new APIs & Format Configulation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# Top-most EditorConfig file
+root = true
+
+# Lua files settings
+[*.lua]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# JSON files settings
+[*.json]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
+  "format": {
+    "defaultConfig": {
+      "indent_style": "space",
+      "indent_size": "2",
+      "continuation_indent": "2",
+      "quote_style": "double",
+      "call_arg_parentheses": "always",
+      "space_before_closure_open_parenthesis": "false",
+      "align_continuous_similar_call_args": "true"
+    }
+  }
+}

--- a/lua/diaglist/debounce.lua
+++ b/lua/diaglist/debounce.lua
@@ -4,6 +4,9 @@ local M = {}
 -- added vim.schedule_wrap
 function M.debounce_trailing(ms, fn)
   local timer = vim.uv.new_timer()
+  if not timer then
+    error('Failed to create timer')
+  end
   return function(...)
     local argv = { ... }
     timer:start(ms, 0, function()

--- a/lua/diaglist/debounce.lua
+++ b/lua/diaglist/debounce.lua
@@ -3,16 +3,16 @@ local M = {}
 -- adopted from https://github.com/lewis6991/gitsigns.nvim/blob/main/lua/gitsigns/debounce.lua
 -- added vim.schedule_wrap
 function M.debounce_trailing(ms, fn)
- local timer = vim.uv.new_timer()
- return function(...)
+  local timer = vim.uv.new_timer()
+  return function(...)
     local argv = { ... }
     timer:start(ms, 0, function()
-       timer:stop()
-       vim.schedule_wrap(function()
-         fn(unpack(argv))
-       end)()
+      timer:stop()
+      vim.schedule_wrap(function()
+        fn(unpack(argv))
+      end)()
     end)
- end
+  end
 end
 
 return M

--- a/lua/diaglist/debounce.lua
+++ b/lua/diaglist/debounce.lua
@@ -3,7 +3,7 @@ local M = {}
 -- adopted from https://github.com/lewis6991/gitsigns.nvim/blob/main/lua/gitsigns/debounce.lua
 -- added vim.schedule_wrap
 function M.debounce_trailing(ms, fn)
- local timer = vim.loop.new_timer()
+ local timer = vim.uv.new_timer()
  return function(...)
     local argv = { ... }
     timer:start(ms, 0, function()

--- a/lua/diaglist/init.lua
+++ b/lua/diaglist/init.lua
@@ -8,12 +8,28 @@ local q = require('diaglist.quickfix')
 local l = require('diaglist.loclist')
 
 function M.init(opts)
-  vim.api.nvim_command [[aug diagnostics]]
-  vim.api.nvim_command [[au!]]
-  vim.api.nvim_command [[au DiagnosticChanged * lua require("diaglist").diagnostics_hook(true)]]
-  vim.api.nvim_command [[au WinEnter * lua require("diaglist").diagnostics_hook(false)]]
-  vim.api.nvim_command [[au BufEnter * lua require("diaglist").diagnostics_hook(false)]]
-  vim.api.nvim_command [[aug END]]
+  local aug_id = vim.api.nvim_create_augroup('diagnostics', {})
+  vim.api.nvim_create_autocmd('DiagnosticChanged', {
+    group = aug_id,
+    pattern = '*',
+    callback = function()
+      require('diaglist').diagnostics_hook(true)
+    end,
+  })
+  vim.api.nvim_create_autocmd('WinEnter', {
+    group = aug_id,
+    pattern = '*',
+    callback = function()
+      require('diaglist').diagnostics_hook(false)
+    end,
+  })
+  vim.api.nvim_create_autocmd('BufEnter', {
+    group = aug_id,
+    pattern = '*',
+    callback = function()
+      require('diaglist').diagnostics_hook(false)
+    end,
+  })
 
   if opts == nil then
     opts = {}

--- a/lua/diaglist/loclist.lua
+++ b/lua/diaglist/loclist.lua
@@ -28,7 +28,7 @@ end
 
 function M.open_buffer_diagnostics()
   M.diagnostics_hook()
-  vim.api.nvim_command [[lw]]
+  vim.cmd.lw()
 end
 
 return M

--- a/lua/diaglist/loclist.lua
+++ b/lua/diaglist/loclist.lua
@@ -4,7 +4,7 @@ local M = {
   debug = false,
 }
 
-function is_open()
+local function is_open()
   return vim.fn.getloclist(0, { winid = 0 }).winid ~= 0
 end
 

--- a/lua/diaglist/loclist.lua
+++ b/lua/diaglist/loclist.lua
@@ -5,7 +5,7 @@ local M = {
 }
 
 function is_open()
-  return vim.fn.getloclist(0, {winid = 0}).winid ~= 0
+  return vim.fn.getloclist(0, { winid = 0 }).winid ~= 0
 end
 
 local function get_as_qfitems()

--- a/lua/diaglist/quickfix.lua
+++ b/lua/diaglist/quickfix.lua
@@ -39,7 +39,7 @@ end
 
 M.open_all_diagnostics = function()
   M.populate_qflist()
-  api.nvim_command('copen')
+  vim.cmd.copen()
 end
 
 M.diagnostics_hook = function()

--- a/lua/diaglist/quickfix.lua
+++ b/lua/diaglist/quickfix.lua
@@ -10,7 +10,7 @@ M.title = 'Workspace Diagnostics'
 M.change_since_render = false
 
 local function is_qf_foreign()
-  return vim.fn.getqflist{ title = 0 }.title ~= M.title
+  return vim.fn.getqflist({ title = 0 }).title ~= M.title
 end
 
 M.populate_qflist = function()
@@ -21,7 +21,7 @@ M.populate_qflist = function()
     return
   end
 
-  if string.sub(priority_uri,0,7) == 'file://' and string.len(priority_uri) > 7 then
+  if string.sub(priority_uri, 0, 7) == 'file://' and string.len(priority_uri) > 7 then
     M.last_priority_uri = priority_uri
   else
     priority_uri = M.last_priority_uri
@@ -33,7 +33,7 @@ M.populate_qflist = function()
   })
 
   vim.fn.setqflist(all_diagnostics, 'r')
-  vim.diagnostic.setqflist({open=false, title = M.title})
+  vim.diagnostic.setqflist({ open = false, title = M.title })
   M.change_since_render = false
 end
 

--- a/lua/diaglist/util.lua
+++ b/lua/diaglist/util.lua
@@ -21,7 +21,7 @@ M.get_qflist = function(opts)
   local all_diags = vim.diagnostic.get(opts.bufnr)
   local qflist = vim.diagnostic.toqflist(all_diags)
 
-  table.sort(qflist, function(a,b)
+  table.sort(qflist, function(a, b)
     local atypen = M.type_to_num(a.type)
     local btypen = M.type_to_num(b.type)
 

--- a/lua/diaglist/util.lua
+++ b/lua/diaglist/util.lua
@@ -30,8 +30,8 @@ M.get_qflist = function(opts)
     end
 
     if atypen == btypen then
-      local aok, auri = pcall(vim.uri_from_bufnr(a.bufnr))
-      local bok, buri = pcall(vim.uri_from_bufnr(b.bufnr))
+      local aok, auri = pcall(function() return vim.uri_from_bufnr(a.bufnr) end)
+      local bok, buri = pcall(function() return vim.uri_from_bufnr(b.bufnr) end)
 
       if aok and bok and auri == buri then
         return a.lnum < b.lnum


### PR DESCRIPTION
Hello.

This PR brings a set of refactors to the codebase.
Thank you for taking the time to review these changes!

---

## Key Changes

### 1. **Adoption of New Neovim APIs**
- Replaces deprecated `vim.api.nvim_command` and direct command strings with `vim.api.nvim_create_augroup`, `vim.api.nvim_create_autocmd`, and `vim.cmd`.
- Update timer creation to use `vim.uv.new_timer()` (instead of `vim.loop.new_timer()`), with nil-check.

### 2. **Formatting and Style**
- Add `.editorconfig` and `.luarc.json` to enforce consistent formatting for Lua and JSON files (2-space indentation, UTF-8, LF line endings, etc.).
- Reformat code for consistent spacing, argument formatting, and style across all Lua modules.

### 3. **Other Changes**
- Fix `pcall` usage by wrapping function calls for correct typing.
- Change `is_open` in `loclist.lua` to a local function to avoid polluting the global namespace, because it seems to be local function.

---

Thank you for your time and for maintaining this project!